### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/packages/core/src/runtime/components/overlay/modal/Modal.vue
+++ b/packages/core/src/runtime/components/overlay/modal/Modal.vue
@@ -65,7 +65,7 @@ export default defineComponent({
     const open = computed({
       get() {
         // disable-next-line
-        if (process.server) return props.modelValue
+        if (import.meta.server) return props.modelValue
         // // Change body attr
         if (!props.scrollBody) {
           if (props.modelValue) document.body.classList.add('overflow-hidden')


### PR DESCRIPTION
This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)