### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/apps/docs/content/0.index.md
+++ b/apps/docs/content/0.index.md
@@ -14,7 +14,7 @@ cta:
 secondary:
   - Open on GitHub →
   - https://github.com/gaetansenn/vunix
-snippet: yarn add @vunix/vue 
+snippet: npx nuxi@latest module add vunix
 ---
 
 #title

--- a/apps/docs/content/1.get-started/2.installation.md
+++ b/apps/docs/content/1.get-started/2.installation.md
@@ -8,21 +8,9 @@ constrainedClass: 'max-w-4xl'
 ## New Project with Nuxt.js
 
 1. Install the dependencies in your Nuxt project:
-
-::code-group
-
-  ```bash [yarn]
-  yarn add @vunix/nuxt
-  ```
-
-  ```bash [npm]
-  npm install @vunix/nuxt
-  ```
-
-  ```bash [pnpm]
-  pnpm install @vunix/nuxt
-  ```
-::
+```bash
+npx nuxi@latest module add vunix
+```
 
 2. Configure your `nuxt.config.ts` to load the module
 
@@ -56,21 +44,9 @@ Check the [nuxt-example](https://github.com/gaetansenn/vunix/tree/main/apps/nuxt
 ## New project with Vue.js
 
 1. Install the dependencies in your Vue project:
-
-::code-group
-
-  ```bash [yarn]
-  yarn add @vunix/vue
-  ```
-
-  ```bash [npm]
-  npm install @vunix/vue
-  ```
-
-  ```bash [pnpm]
-  pnpm install @vunix/vue
-  ```
-::
+```bash
+npx nuxi@latest module add vunix
+```
 
 ### Global components import
 1. Add the Vunix vue plugin to your app


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
